### PR TITLE
Updates to allow Ops to play, allow Creative mode, and fix code composition (#1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.kermx</groupId>
     <artifactId>DesirePaths</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>DesirePaths</name>
@@ -68,10 +68,6 @@
         <repository>
             <id>sk89q-repo</id>
             <url>https://maven.enginehub.org/repo/</url>
-        </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 

--- a/src/main/java/me/kermx/desirepaths/DesirePaths.java
+++ b/src/main/java/me/kermx/desirepaths/DesirePaths.java
@@ -1,12 +1,18 @@
 package me.kermx.desirepaths;
 
-import com.palmergames.bukkit.towny.object.TownyPermission;
-import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
-import me.kermx.desirepaths.commands.DesirePathsCommand;
-import me.kermx.desirepaths.integrations.WorldGuardIntegration;
-//import me.kermx.desirepaths.managers.SpeedBoostHandler;
-import me.kermx.desirepaths.managers.ToggleManager;
-import org.bukkit.*;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.enchantments.Enchantment;
@@ -20,11 +26,15 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.*;
-import java.util.concurrent.ThreadLocalRandom;
+import com.palmergames.bukkit.towny.object.TownyPermission;
+import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
+
+import me.kermx.desirepaths.commands.DesirePathsCommand;
+import me.kermx.desirepaths.integrations.WorldGuardIntegration;
+//import me.kermx.desirepaths.managers.SpeedBoostHandler;
+import me.kermx.desirepaths.managers.ToggleManager;
 
 public final class DesirePaths extends JavaPlugin implements Listener {
-
     private List<String> disabledWorlds;
     private boolean movementCheckEnabled;
     private int noBootsChance;
@@ -36,12 +46,18 @@ public final class DesirePaths extends JavaPlugin implements Listener {
     private int ridingPigChance;
     private int sprintingBlockBelowChance;
     private int sprintingBlockAtFeetChance;
+    private int attemptFrequency;
     private List<String> blockBelowSwitcherConfig;
     private List<String> blockAtFeetSwitcherConfig;
     private boolean pathsOnlyWherePlayerCanBreak;
+    private boolean enableInCreativeMode;
 
     private final ThreadLocalRandom random = ThreadLocalRandom.current();
-    private enum modifierType{NO_BOOTS, LEATHER_BOOTS, HAS_BOOTS, FEATHER_FALLING, RIDING_HORSE, RIDING_BOAT, RIDING_PIG}
+
+    private enum modifierType {
+        NO_BOOTS, LEATHER_BOOTS, HAS_BOOTS, FEATHER_FALLING, RIDING_HORSE, RIDING_BOAT, RIDING_PIG
+    }
+
     private WorldGuardIntegration worldGuardIntegration;
 
     private boolean townyEnabled;
@@ -60,12 +76,13 @@ public final class DesirePaths extends JavaPlugin implements Listener {
         }
     }
 
-    //PlayerMoveEvent related stuff
+    // PlayerMoveEvent related stuff
     private boolean playerHasMoved = false;
+
     @EventHandler
     private void onPlayerMove(PlayerMoveEvent event) {
         if (!movementCheckEnabled) {
-            return;  // Do nothing if movementCheckEnabled is false
+            return; // Do nothing if movementCheckEnabled is false
         }
 
         double deltaX = Math.abs(event.getFrom().getX() - event.getTo().getX());
@@ -78,9 +95,175 @@ public final class DesirePaths extends JavaPlugin implements Listener {
     public void onEnable() {
         // Load config
         saveDefaultConfig();
-        reloadConfig();
+        getConfig().options().copyDefaults(true);
+        saveConfig();
+        loadConfig();
+
+        // initialize reload & toggle command
+        Objects.requireNonNull(getCommand("desirepaths")).setExecutor(new DesirePathsCommand(this));
+
+        // initialize the speedboosthandler
+        // Bukkit.getPluginManager().registerEvents(new SpeedBoostHandler(this), this);
+
+        // initialize togglemanager
+        toggleManager = new ToggleManager(this);
+
+        // Plugin startup logic
+        Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (movementCheckEnabled && playerHasMoved) {
+                    playerHandler(player, noBootsChance, leatherBootsChance, hasBootsChance, featherFallingChance,
+                            ridingHorseChance, ridingBoatChance, ridingPigChance, sprintingBlockBelowChance,
+                            sprintingBlockAtFeetChance, blockAtFeetSwitcherConfig, blockBelowSwitcherConfig);
+                } else if (movementCheckEnabled) {
+                    return;
+                } else {
+                    playerHandler(player, noBootsChance, leatherBootsChance, hasBootsChance, featherFallingChance,
+                            ridingHorseChance, ridingBoatChance, ridingPigChance, sprintingBlockBelowChance,
+                            sprintingBlockAtFeetChance, blockAtFeetSwitcherConfig, blockBelowSwitcherConfig);
+                }
+            }
+        }, 0L, attemptFrequency);
+
+        getServer().getPluginManager().registerEvents(this, this);
+
+        Bukkit.getConsoleSender()
+                .sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths enabled successfully");
+
+        // check if towny & worldguard are installed
+        townyEnabled = Bukkit.getPluginManager().isPluginEnabled("Towny");
+        if (townyEnabled) {
+            Bukkit.getConsoleSender()
+                    .sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths-Towny integration successful");
+        }
+
+        worldGuardEnabled = Bukkit.getPluginManager().isPluginEnabled("WorldGuard");
+        if (worldGuardEnabled) {
+            Bukkit.getConsoleSender().sendMessage(
+                    ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths-WorldGuard integration successful");
+        }
+    }
+
+    private void playerHandler(Player player, int noBootsChance, int leatherBootsChance, int hasBootsChance,
+            int featherFallingChance, int ridingHorseChance, int ridingBoatChance, int ridingPigChance,
+            int sprintingBlockBelowChance, int sprintingBlockAtFeetChance, List<String> blockAtFeetSwitcherConfig,
+            List<String> blockBelowSwitcherConfig) {
+        if (player.getGameMode() != GameMode.SURVIVAL && !enableInCreativeMode) {
+            return;
+        }
+        boolean pathsToggledOff = !getToggleManager().getToggle(player.getUniqueId());
+        if (pathsToggledOff) {
+            return;
+        }
+        int chance = getChance(player, noBootsChance, leatherBootsChance, hasBootsChance, featherFallingChance,
+                ridingHorseChance, ridingBoatChance, ridingPigChance);
+        int randomNum = random.nextInt(100);
+        Bukkit.getScheduler().runTask(this,
+                () -> blockHandler(player.getLocation().getBlock().getRelative(BlockFace.DOWN), player, chance,
+                        randomNum, sprintingBlockBelowChance, blockBelowSwitcherConfig));
+        Bukkit.getScheduler().runTask(this, () -> blockHandler(player.getLocation().getBlock(), player, chance,
+                randomNum, sprintingBlockAtFeetChance, blockAtFeetSwitcherConfig));
+    }
+
+    public static int getChance(Player player, int noBootsChance, int leatherBootsChance, int hasBootsChance,
+            int featherFallingChance, int ridingHorseChance, int ridingBoatChance, int ridingPigChance) {
+        return switch (getModifier(player)) {
+        case RIDING_HORSE -> ridingHorseChance;
+        case RIDING_BOAT -> ridingBoatChance;
+        case RIDING_PIG -> ridingPigChance;
+        case FEATHER_FALLING -> featherFallingChance;
+        case HAS_BOOTS -> hasBootsChance;
+        case LEATHER_BOOTS -> leatherBootsChance;
+        case NO_BOOTS -> noBootsChance;
+        };
+    }
+
+    // determine modifier to use for chance
+    private static modifierType getModifier(Player player) {
+        if (player.getVehicle() instanceof Horse)
+            return modifierType.RIDING_HORSE;
+        if (player.getVehicle() instanceof Boat)
+            return modifierType.RIDING_BOAT;
+        if (player.getVehicle() instanceof Pig)
+            return modifierType.RIDING_PIG;
+        ItemStack boots = player.getInventory().getBoots();
+        if (boots == null)
+            return modifierType.NO_BOOTS;
+        Material bootMaterial = boots.getType();
+        Set<Material> bootMaterials = EnumSet.of(Material.IRON_BOOTS, Material.GOLDEN_BOOTS, Material.DIAMOND_BOOTS,
+                Material.NETHERITE_BOOTS, Material.LEATHER_BOOTS);
+        Optional<Enchantment> featherFallingEnchantment = boots.getEnchantments().keySet().stream()
+                .filter(Enchantment.PROTECTION_FALL::equals).findFirst();
+        if (bootMaterials.contains(bootMaterial)) {
+            if (featherFallingEnchantment.isPresent()) {
+                return modifierType.FEATHER_FALLING;
+            } else {
+                return modifierType.HAS_BOOTS;
+            }
+        } else if (bootMaterial == Material.LEATHER_BOOTS) {
+            return modifierType.LEATHER_BOOTS;
+        } else {
+            return modifierType.NO_BOOTS;
+        }
+    }
+
+    // Handle block at the players feet
+    private void blockHandler(Block block, Player player, int chance, int randomNum, int sprintingChance,
+            List<String> switcherConfig) {
+        if (disabledWorlds.contains(player.getWorld().getName())) {
+            return;
+        }
+        if (worldGuardEnabled) {
+            if (worldGuardIntegration.checkFlag(player)) {
+                return;
+            }
+        }
+        if (!townyEnabled || !pathsOnlyWherePlayerCanBreak) {
+            // Run towny not enabled
+            if (!player.isSprinting() && randomNum < chance) {
+                blockSwitcher(block, switcherConfig);
+            }
+            if (player.isSprinting() && randomNum < chance + sprintingChance) {
+                blockSwitcher(block, switcherConfig);
+            }
+        } else {
+            // Run if towny is enabled and canBuild is true
+            boolean canBuild = PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(),
+                    TownyPermission.ActionType.DESTROY);
+            if (canBuild) {
+                if (!player.isSprinting() && randomNum < chance) {
+                    blockSwitcher(block, switcherConfig);
+                }
+                if (player.isSprinting() && randomNum < chance + sprintingChance) {
+                    blockSwitcher(block, switcherConfig);
+                }
+            }
+        }
+    }
+
+    private void blockSwitcher(Block block, List<String> switcherConfig) {
+        Material type = block.getType();
+        Map<Material, Material> blockSwitcher = new HashMap<>();
+        for (String switchCase : switcherConfig) {
+            String[] parts = switchCase.split(":");
+            Material sourceMaterial = Material.matchMaterial(parts[0]);
+            Material targetMaterial = Material.matchMaterial(parts[1]);
+            if (sourceMaterial != null && targetMaterial != null) {
+                blockSwitcher.put(sourceMaterial, targetMaterial);
+            } else {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.RED
+                        + " Invalid block switch case in blockModifications: " + switchCase);
+            }
+        }
+        Material targetMaterial = blockSwitcher.get(type);
+        if (targetMaterial != null) {
+            block.setType(targetMaterial);
+        }
+    }
+
+    public void loadConfig() {
         // initial config attemptFrequency value
-        int attemptFrequency = getConfig().getInt("attemptFrequency");
+        attemptFrequency = getConfig().getInt("attemptFrequency");
         // initial config disabledWorlds list
         disabledWorlds = getConfig().getStringList("disabledWorlds");
         // initial config movementCheckEnabled boolean
@@ -101,227 +284,15 @@ public final class DesirePaths extends JavaPlugin implements Listener {
         // initial config townyModifiers booleans
         pathsOnlyWherePlayerCanBreak = getConfig().getBoolean("townyModifiers.pathsOnlyWherePlayerCanBreak");
 
-        // initialize reload & toggle command
-        Objects.requireNonNull(getCommand("desirepaths")).setExecutor(new DesirePathsCommand(this));
-
-        // initialize the speedboosthandler
-        //Bukkit.getPluginManager().registerEvents(new SpeedBoostHandler(this), this);
-
-        // initialize togglemanager
-        toggleManager = new ToggleManager(this);
-
-
-        // Plugin startup logic
-        Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
-            for (Player player : Bukkit.getOnlinePlayers()) {
-                if (movementCheckEnabled && playerHasMoved) {
-                    playerHandler(player, noBootsChance, leatherBootsChance, hasBootsChance, featherFallingChance, ridingHorseChance, ridingBoatChance, ridingPigChance, sprintingBlockBelowChance, sprintingBlockAtFeetChance, blockAtFeetSwitcherConfig, blockBelowSwitcherConfig);
-                } else if (movementCheckEnabled) {
-                    return;
-                } else {
-                    playerHandler(player, noBootsChance, leatherBootsChance, hasBootsChance, featherFallingChance, ridingHorseChance, ridingBoatChance, ridingPigChance, sprintingBlockBelowChance, sprintingBlockAtFeetChance, blockAtFeetSwitcherConfig, blockBelowSwitcherConfig);
-                }
-            }
-        }, 0L, attemptFrequency);
-
-        getServer().getPluginManager().registerEvents(this,this);
-        // check if towny & worldguard are installed
-        townyEnabled = Bukkit.getPluginManager().isPluginEnabled("Towny");
-        worldGuardEnabled = Bukkit.getPluginManager().isPluginEnabled("WorldGuard");
-        if (townyEnabled && worldGuardEnabled) {
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths enabled successfully");
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths-Towny integration successful");
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths-WorldGuard integration successful");
-        } else if (townyEnabled){
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths enabled successfully");
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths-Towny integration successful");
-        } else if (worldGuardEnabled){
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths enabled successfully");
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths-WorldGuard integration successful");
-        } else {
-            Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.GREEN + " DesirePaths enabled successfully");
-        }
+        enableInCreativeMode = getConfig().getBoolean("enableInCreativeMode");
     }
 
-
-    private void playerHandler(Player player, int noBootsChance, int leatherBootsChance, int hasBootsChance, int featherFallingChance, int ridingHorseChance, int ridingBoatChance, int ridingPigChance, int sprintingBlockBelowChance, int sprintingBlockAtFeetChance, List<String> blockAtFeetSwitcherConfig, List<String> blockBelowSwitcherConfig) {
-        if (player.getGameMode() != GameMode.SURVIVAL || player.hasPermission("desirepaths.exempt"))
-            return;
-        boolean pathsToggledOff = !getToggleManager().getToggle(player.getUniqueId());
-        if (pathsToggledOff)
-            return;
-        int chance = getChance(player, noBootsChance, leatherBootsChance, hasBootsChance, featherFallingChance, ridingHorseChance, ridingBoatChance, ridingPigChance);
-        int randomNum = random.nextInt(100);
-        Bukkit.getScheduler().runTask(this,()-> blockBelowHandler(player.getLocation().getBlock().getRelative(BlockFace.DOWN), player, chance, randomNum, sprintingBlockBelowChance, blockBelowSwitcherConfig));
-        Bukkit.getScheduler().runTask(this,()-> blockAtFeetHandler(player.getLocation().getBlock(),player, chance, randomNum, sprintingBlockAtFeetChance, blockAtFeetSwitcherConfig));
-    }
-
-    public static int getChance(Player player, int noBootsChance, int leatherBootsChance, int hasBootsChance, int featherFallingChance, int ridingHorseChance, int ridingBoatChance, int ridingPigChance) {
-        return switch (getModifier(player)) {
-            case RIDING_HORSE -> ridingHorseChance;
-            case RIDING_BOAT -> ridingBoatChance;
-            case RIDING_PIG -> ridingPigChance;
-            case FEATHER_FALLING -> featherFallingChance;
-            case HAS_BOOTS -> hasBootsChance;
-            case LEATHER_BOOTS -> leatherBootsChance;
-            case NO_BOOTS -> noBootsChance;
-        };
-    }
-    //determine modifier to use for chance
-    private static modifierType getModifier(Player player){
-        if (player.getVehicle() instanceof Horse)
-            return modifierType.RIDING_HORSE;
-        if (player.getVehicle() instanceof Boat)
-            return modifierType.RIDING_BOAT;
-        if (player.getVehicle() instanceof Pig)
-            return modifierType.RIDING_PIG;
-        ItemStack boots = player.getInventory().getBoots();
-        if (boots == null)
-            return modifierType.NO_BOOTS;
-        Material bootMaterial = boots.getType();
-        Set<Material> bootMaterials = EnumSet.of(Material.IRON_BOOTS,Material.GOLDEN_BOOTS,Material.DIAMOND_BOOTS,Material.NETHERITE_BOOTS,Material.LEATHER_BOOTS);
-        Optional<Enchantment> featherFallingEnchantment = boots.getEnchantments().keySet().stream().filter(Enchantment.PROTECTION_FALL::equals).findFirst();
-        if (bootMaterials.contains(bootMaterial)){
-            if (featherFallingEnchantment.isPresent()){
-                return modifierType.FEATHER_FALLING;
-            } else {
-                return modifierType.HAS_BOOTS;
-            }
-        } else if (bootMaterial == Material.LEATHER_BOOTS){
-            return modifierType.LEATHER_BOOTS;
-        } else {
-            return modifierType.NO_BOOTS;
-        }
-    }
-    //Handle block at the players feet
-    private void blockAtFeetHandler(Block block, Player player, int chance, int randomNum, int sprintingBlockAtFeetChance, List<String> blockAtFeetSwitcherConfig) {
-        if (disabledWorlds.contains(player.getWorld().getName())){
-            return;
-        }
-        if (worldGuardEnabled){
-            if (worldGuardIntegration.checkFlag(player)) {
-                return;
-            }
-        }
-        if (!townyEnabled || !pathsOnlyWherePlayerCanBreak) {
-            // Run towny not enabled
-            if (!player.isSprinting() && randomNum < chance) {
-                blockAtFeetSwitcher(block, blockAtFeetSwitcherConfig);
-            }
-            if (player.isSprinting() && randomNum < chance + sprintingBlockAtFeetChance) {
-                blockAtFeetSwitcher(block, blockAtFeetSwitcherConfig);
-            }
-        } else {
-            // Run if towny is enabled and canBuild is true
-            boolean canBuild = PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(), TownyPermission.ActionType.DESTROY);
-            if (canBuild) {
-                if (!player.isSprinting() && randomNum < chance) {
-                    blockAtFeetSwitcher(block, blockAtFeetSwitcherConfig);
-                }
-                if (player.isSprinting() && randomNum < chance + sprintingBlockAtFeetChance) {
-                    blockAtFeetSwitcher(block, blockAtFeetSwitcherConfig);
-                }
-            }
-        }
-    }
-    private void blockAtFeetSwitcher(Block block, List<String> blockAtFeetSwitcherConfig) {
-        Material type = block.getType();
-        Map<Material, Material> blockSwitcher = new HashMap<>();
-        for (String switchCase : blockAtFeetSwitcherConfig) {
-            String[] parts = switchCase.split(":");
-            Material sourceMaterial = Material.matchMaterial(parts[0]);
-            Material targetMaterial = Material.matchMaterial(parts[1]);
-            if (sourceMaterial != null && targetMaterial != null) {
-                blockSwitcher.put(sourceMaterial, targetMaterial);
-            } else {
-                Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.RED + " Invalid block switch case in blockAtFeetModifications: " + switchCase);
-            }
-        }
-        Material targetMaterial = blockSwitcher.get(type);
-        if (targetMaterial != null) {
-            block.setType(targetMaterial);
-        }
-    }
-
-    //Handle block below the player
-    private void blockBelowHandler(Block block, Player player, int chance, int randomNum, int sprintingBlockBelowChance, List<String> blockBelowSwitcherConfig) {
-        if (disabledWorlds.contains(player.getWorld().getName())){
-            return;
-        }
-        if (worldGuardEnabled){
-            if (worldGuardIntegration.checkFlag(player)) {
-                return;
-            }
-        }
-        if (!townyEnabled || !pathsOnlyWherePlayerCanBreak) {
-            // Run towny not enabled
-            if (!player.isSprinting() && randomNum < chance) {
-                blockBelowSwitcher(block, blockBelowSwitcherConfig);
-            }
-            if (player.isSprinting() && randomNum < chance + sprintingBlockBelowChance) {
-                blockBelowSwitcher(block, blockBelowSwitcherConfig);
-            }
-        } else {
-            // Run if towny is enabled and canBuild is true
-            boolean canBuild = PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getType(), TownyPermission.ActionType.DESTROY);
-            if (canBuild) {
-                if (!player.isSprinting() && randomNum < chance) {
-                    blockBelowSwitcher(block, blockBelowSwitcherConfig);
-                }
-                if (player.isSprinting() && randomNum < chance + sprintingBlockBelowChance) {
-                    blockBelowSwitcher(block, blockBelowSwitcherConfig);
-                }
-            }
-        }
-    }
-    private void blockBelowSwitcher(Block block, List<String> blockBelowSwitcherConfig) {
-        Material type = block.getType();
-        Map<Material, Material> blockSwitcher = new HashMap<>();
-        for (String switchCase : blockBelowSwitcherConfig) {
-            String[] parts = switchCase.split(":");
-            Material sourceMaterial = Material.matchMaterial(parts[0]);
-            Material targetMaterial = Material.matchMaterial(parts[1]);
-            if (sourceMaterial != null && targetMaterial != null) {
-                blockSwitcher.put(sourceMaterial, targetMaterial);
-            } else {
-                Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.RED + " Invalid block switch case in blockBelowModifications: " + switchCase);
-            }
-        }
-        Material targetMaterial = blockSwitcher.get(type);
-        if (targetMaterial != null) {
-            block.setType(targetMaterial);
-        }
-    }
-    public void loadConfig() {
-        reloadConfig();
-        // config disabledWorlds list
-        disabledWorlds = getConfig().getStringList("disabledWorlds");
-        // config movementCheckEnabled boolean
-        movementCheckEnabled = getConfig().getBoolean("movementCheckEnabled");
-        // config chanceModifier values
-        noBootsChance = getConfig().getInt("chanceModifiers.NO_BOOTS");
-        leatherBootsChance = getConfig().getInt("chanceModifiers.LEATHER_BOOTS");
-        hasBootsChance = getConfig().getInt("chanceModifiers.HAS_BOOTS");
-        featherFallingChance = getConfig().getInt("chanceModifiers.FEATHER_FALLING");
-        ridingHorseChance = getConfig().getInt("chanceModifiers.RIDING_HORSE");
-        ridingBoatChance = getConfig().getInt("chanceModifiers.RIDING_BOAT");
-        ridingPigChance = getConfig().getInt("chanceModifiers.RIDING_PIG");
-        sprintingBlockBelowChance = getConfig().getInt("chanceModifiers.SPRINTING_BLOCK_BELOW");
-        sprintingBlockAtFeetChance = getConfig().getInt("chanceModifiers.SPRINTING_BLOCK_AT_FEET");
-        // config blockModifications Lists
-        blockBelowSwitcherConfig = getConfig().getStringList("blockModifications.blockBelowModifications");
-        blockAtFeetSwitcherConfig = getConfig().getStringList("blockModifications.blockAtFeetModifications");
-        // config townyModifiers booleans
-        pathsOnlyWherePlayerCanBreak = getConfig().getBoolean("townyModifiers.pathsOnlyWherePlayerCanBreak");
-    }
-
-    public ToggleManager getToggleManager(){
+    public ToggleManager getToggleManager() {
         return toggleManager;
     }
 
     @Override
     public void onDisable() {
         Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + ">>" + ChatColor.RED + " DesirePaths Disabled");
-        // Plugin shutdown logic
     }
 }

--- a/src/main/java/me/kermx/desirepaths/commands/DesirePathsCommand.java
+++ b/src/main/java/me/kermx/desirepaths/commands/DesirePathsCommand.java
@@ -1,11 +1,15 @@
 package me.kermx.desirepaths.commands;
 
-import me.kermx.desirepaths.DesirePaths;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import me.kermx.desirepaths.DesirePaths;
 
 public class DesirePathsCommand implements CommandExecutor {
 
@@ -33,13 +37,27 @@ public class DesirePathsCommand implements CommandExecutor {
                 }
                 if (sender.hasPermission("desirepaths.toggle")) {
                     Player player = (Player) sender;
-                    boolean currentToggle = plugin.getToggleManager().getToggle(player.getUniqueId());
-                    boolean newToggle = !currentToggle;
-
-                    plugin.getToggleManager().setToggle(player.getUniqueId(), newToggle);
+                    boolean newToggle = plugin.getToggleManager().toggle(player.getUniqueId());
 
                     String toggleStatus = newToggle ? "on" : "off";
                     player.sendMessage(ChatColor.GREEN + "DesirePaths toggled " + toggleStatus + "!");
+                    return true;
+                }
+            }
+            // Handle console command to toggle players by name
+            if (args.length == 2 && args[0].equalsIgnoreCase("toggle")) {
+                if (!(sender instanceof Player)) {
+                    String playerName = args[1];
+                    Player togglePlayer = Bukkit.getPlayer(playerName);
+                    if (togglePlayer != null) {
+                        UUID playerId = togglePlayer.getUniqueId();
+                        boolean newToggle = plugin.getToggleManager().toggle(playerId);
+
+                        String toggleStatus = newToggle ? "on" : "off";
+                        sender.sendMessage(ChatColor.GREEN + "DesirePaths toggled " + toggleStatus + "!");
+                    } else {
+                        sender.sendMessage(ChatColor.GREEN + "Unable to find online player with name: " + playerName);
+                    }
                     return true;
                 }
             }

--- a/src/main/java/me/kermx/desirepaths/managers/ToggleManager.java
+++ b/src/main/java/me/kermx/desirepaths/managers/ToggleManager.java
@@ -1,14 +1,15 @@
 package me.kermx.desirepaths.managers;
 
-import me.kermx.desirepaths.DesirePaths;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import me.kermx.desirepaths.DesirePaths;
 
 public class ToggleManager {
 
@@ -42,6 +43,13 @@ public class ToggleManager {
             boolean toggleState = toggleDataConfig.getBoolean(playerIdString);
             toggleMap.put(playerId, toggleState);
         }
+    }
+
+    public boolean toggle(UUID playerId) {
+        boolean currentToggle = getToggle(playerId);
+        boolean newToggle = !currentToggle;
+        setToggle(playerId, newToggle);
+        return newToggle;
     }
 
     private void saveToggleData() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,9 +36,9 @@ blockModifications:
 ## Blocks at the same level as the player's feet
   blockAtFeetModifications:
     - SNOW:AIR
-    - GRASS:AIR
+    - SHORT_GRASS:AIR
     - FERN:AIR
-    - TALL_GRASS:GRASS
+    - TALL_GRASS:SHORT_GRASS
 ## Blocks below that the player is standing on
   blockBelowModifications:
     - GRASS_BLOCK:DIRT
@@ -55,3 +55,6 @@ blockModifications:
 ## Controls if paths can be made anywhere or only in locations where the player is allowed to break blocks
 townyModifiers:
   pathsOnlyWherePlayerCanBreak: true
+  
+# Flag to enable / disable desire paths in Creative mode
+enableInCreativeMode: true


### PR DESCRIPTION
I really enjoy the DesirePaths plugin and think it's a neat touch to add to SMP games. I really want to be able to use this on my family server where we all mostly plays as Ops, so I decided to fork it and make some updates. I'm hoping maybe you won't mind some collaboration?

I'll list at a high level the handful of changes I made in this PR, and within the code itself I'll leave comments to explain various sections.

- Updated it so that you could create paths as an Op - I realized this was occurring due to the permission check for `desirepaths.exempt`, since Op has `*` permissions then they were being exempt. I reasoned that this was duplicate functionality  to the toggle. If the admins wanted to disable paths for a user they could simply toggle them off and take away their permissions to toggle themselves with `desirepaths.toggle`
  - To address this I remove the check for `desirepaths.exempt` and add functionality for console admin to manage toggles by username
- We also sometimes like to play on creative, but we like to walk around and such, so it would be nice to use the paths there as well - I added a new config option `enableInCreativeMode` to allow enabling in Creative mode via config option
- A fair bit of code cleanup - removed a couple of duplicated methods, and updated to use the existing `loadConfig()` method
- Formatted code to keep it consistent with spacing, line breaks, avoid long lines, sorting the imports, etc.

Please let me know your thoughts!